### PR TITLE
settings schema & validation / fix duplicate chat message history

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,13 @@
   "scripts": {
     "start": "bun run ./src/main.ts",
     "build": "bun build --target=bun ./src/main.ts --outfile=./dist/main.js",
-    "dev": "bun --watch ./src/main.ts rename my git branch"
+    "dev": "bun --watch ./src/main.ts rename my git branch",
+    "dev:debug": "bun --watch ./src/main.ts rename my git branch --debug",
+    "dev:init": "bun --watch ./src/main.ts --init"
   },
   "dependencies": {
-    "chalk": "^5.3.0"
+    "chalk": "^5.3.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -8,6 +8,9 @@ dependencies:
   chalk:
     specifier: ^5.3.0
     version: 5.3.0
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
 
 devDependencies:
   '@types/node':
@@ -39,3 +42,7 @@ packages:
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false

--- a/src/settings/get-headers.ts
+++ b/src/settings/get-headers.ts
@@ -1,35 +1,14 @@
-import { Settings } from "./get-settings";
+import { Settings } from "./settings-schema";
 
 export function getHeaders(settings: Settings) {
   const headers = {
     "Content-Type": "application/json",
   };
-
   if (settings.service === "openai") {
     headers["Authorization"] = `Bearer ${settings.openai?.key}`;
   }
-
-  if (settings.service === "cloudflare") {
-    headers["CF-Access-Client-Id"] = settings.cloudflare?.client_id;
-    headers["CF-Access-Client-Secret"] = settings.cloudflare?.client_secret;
-  }
-
   if (settings.headers) {
     Object.assign(headers, settings.headers);
   }
-
   return headers;
-}
-
-export function getEndpoint(settings: Settings): string {
-  if (settings.service === "openai") {
-    return "https://api.openai.com/v1/chat/completions";
-  }
-
-  if (settings.endpoint) {
-    return settings.endpoint;
-  }
-
-  console.error(`Failed to resolve endpoint from settings: ${settings}`);
-  return "";
 }

--- a/src/settings/get-settings.ts
+++ b/src/settings/get-settings.ts
@@ -1,113 +1,40 @@
-import chalk from "chalk";
 import { initializeSettings } from "./initialize-settings";
 import { settingsFilePath } from "./settings-constants";
 import fs from "fs";
 import readline from "readline";
+import { Settings, validateSettings } from "./settings-schema";
+import { debug } from "../utils/debug-log";
 
 export async function getSettings({
   rl,
 }: {
   rl: readline.Interface;
 }): Promise<Settings> {
-  let settings;
+  let settings: Settings | undefined;
+  let settingsFile: string | undefined;
+
   try {
-    settings = JSON.parse(fs.readFileSync(settingsFilePath, "utf8"));
+    settingsFile = fs.readFileSync(settingsFilePath, "utf8");
   } catch (error) {
-    console.log(chalk.red(`Settings file not found. at ${settingsFilePath}`));
     await initializeSettings(rl);
   }
 
-  if (settings) {
-    try {
-      validateSettings(settings);
-      return settings;
-    } catch (err: any) {
-      console.log(
-        chalk.red(`Error validating settings at ${settingsFilePath}`)
-      );
-      console.log(chalk.red(err?.message));
-      process.exit(1);
+  try {
+    if (settingsFile) {
+      settings = JSON.parse(settingsFile);
     }
-  }
-
-  return settings;
-}
-
-export const services = ["custom", "cloudflare", "openai"] as const;
-
-export type Settings = {
-  /**
-   * The endpoint of the server
-   */
-  endpoint?: string;
-
-  /**
-   * The service to use for the request
-   */
-  service?: (typeof services)[number];
-
-  /**
-   * The AI model to use for the request
-   * @default gpt-3.5-turbo
-   */
-  model?: string;
-
-  /**
-   * Your API key for OpenAI
-   */
-  openai?: {
-    key: string;
-  };
-
-  /**
-   * The client id and secret for cloudflare service token authentication
-   */
-  cloudflare?: {
-    client_id: string;
-    client_secret: string;
-  };
-
-  /**
-   * Any additional headers to send with the request
-   */
-  headers?: {
-    [key: string]: string;
-  };
-};
-
-function validateSettings(settings) {
-  if (
-    (settings.service === "custom" || settings.service === "cloudflare") &&
-    !settings.endpoint
-  ) {
-    throw new Error(
-      `"endpoint" is required when using service "${settings.service}".`
+  } catch (error) {
+    debug.error(
+      `Error parsing JSON ${settingsFilePath}\n\nYou can edit your settings file manually to resolve the issue, or try reinitializing a new settings file by running the following command: \n\x1b[36mai --init\n`
     );
+    process.exit(1);
   }
-  if (!settings.service) {
-    throw new Error(
-      `"service" is required. Must be one of ${services.join(", ")}`
-    );
+
+  if (settings) {
+    validateSettings(settings);
+    return settings;
   }
-  if (settings.service === "openai" && !settings.openai) {
-    throw new Error(`OpenAI settings are required when using "openai" service`);
-  }
-  if (settings.service === "cloudflare" && !settings.cloudflare) {
-    throw new Error(
-      `Cloudflare settings are required when using "cloudflare" service`
-    );
-  }
-  if (settings.service === "cloudflare" && !settings.cloudflare.client_id) {
-    throw new Error(
-      `cloudflare.client_id is required when using "cloudflare" service`
-    );
-  }
-  if (settings.service === "cloudflare" && !settings.cloudflare.client_secret) {
-    throw new Error(
-      `cloudflare.client_secret is required when using "cloudflare" service`
-    );
-  }
-  if (settings.service === "openai" && !settings.openai.key) {
-    throw new Error(`OpenAI api_key is required when using "openai" service`);
-  }
+
+  debug.error("Failed to read settings file");
+  process.exit(1);
 }

--- a/src/settings/save-settings.ts
+++ b/src/settings/save-settings.ts
@@ -1,7 +1,12 @@
 import fs from "fs";
 import { settingsFilePath } from "./settings-constants";
-import { Settings } from "./get-settings";
+import { Settings } from "./settings-schema";
+import { debug } from "../utils/debug-log";
 
 export function saveSettings(settings: Settings) {
-  fs.writeFileSync(settingsFilePath, JSON.stringify(settings, null, 2));
+  try {
+    fs.writeFileSync(settingsFilePath, JSON.stringify(settings, null, 2));
+  } catch (err: any) {
+    debug.error(`Error saving settings file: ${err.message}`);
+  }
 }

--- a/src/settings/settings-constants.ts
+++ b/src/settings/settings-constants.ts
@@ -10,6 +10,7 @@ const kernelVersion = os.version();
 export const settingsDir = `${homeDir}/.cookie-ai`;
 export const settingsFileName = `settings.json`;
 export const settingsFilePath = `${settingsDir}/${settingsFileName}`;
+export const services = ["openai", "custom"] as const;
 const dirName = import.meta.dir;
 
 let schemaPath = dirName?.includes("src")

--- a/src/settings/settings-schema.ts
+++ b/src/settings/settings-schema.ts
@@ -12,6 +12,9 @@ const openaiSchema = z.object({
     required_error: errors.OPENAI_KEY_REQUIRED,
   }),
 });
+const customSchema = z.object({
+  payload: z.record(z.string()).optional(),
+});
 
 export const settingsSchema = z
   .object({
@@ -21,6 +24,7 @@ export const settingsSchema = z
       required_error: "'model' is required. (example: 'gpt-4')",
     }),
     openai: openaiSchema.optional(),
+    custom: customSchema.optional(),
     headers: z.record(z.string()).optional(),
   })
   .refine((data) => data.service !== "openai" || data.openai, {

--- a/src/settings/settings-schema.ts
+++ b/src/settings/settings-schema.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { debug } from "../utils/debug-log";
+import { settingsDir } from "./settings-constants";
+
+const errors = {
+  OPENAI_KEY_REQUIRED: "'openai.key' is required when using service 'openai'",
+  ENDPOINT_REQUIRED: "'endpoint' is required when using service 'custom'",
+};
+
+const openaiSchema = z.object({
+  key: z.string({
+    required_error: errors.OPENAI_KEY_REQUIRED,
+  }),
+});
+
+export const settingsSchema = z
+  .object({
+    endpoint: z.string().url().optional(),
+    service: z.enum(["custom", "openai"]),
+    model: z.string({
+      required_error: "'model' is required. (example: 'gpt-4')",
+    }),
+    openai: openaiSchema.optional(),
+    headers: z.record(z.string()).optional(),
+  })
+  .refine((data) => data.service !== "openai" || data.openai, {
+    message: errors.OPENAI_KEY_REQUIRED,
+    path: ["openai"],
+  })
+  .refine((data) => data.service !== "custom" || data.endpoint, {
+    message: errors.ENDPOINT_REQUIRED,
+    path: ["endpoint"],
+  });
+
+export type Settings = z.infer<typeof settingsSchema>;
+
+export function validateSettings(settings) {
+  const result = settingsSchema.safeParse(settings);
+  if (!result.success) {
+    for (const error of result.error.issues) {
+      debug.error(`settings.json: ${error.message}\n
+You can edit your settings file at file://${settingsDir}
+or run 'ai --init' to re-initialize your settings.\n`);
+    }
+    process.exit(1);
+  }
+}

--- a/src/utils/debug-log.ts
+++ b/src/utils/debug-log.ts
@@ -1,0 +1,62 @@
+function debugLog(
+  message: string | Record<string, unknown>,
+  level: "error" | "log" | "warn" | "info" = "log",
+  overridePrefix?: string
+) {
+  const prefix = overridePrefix || "[cookie-ai-cli]";
+  const prefixColor = "\x1b[32m";
+
+  const messagePrefix = (() => {
+    switch (level) {
+      case "error":
+        return "\x1b[31m"; // Red
+      case "warn":
+        return "\x1b[33m"; // Yellow
+      case "info":
+        return "\x1b[36m"; // Cyan
+      default:
+        return ""; // No color
+    }
+  })();
+
+  const reset = "\x1b[0m"; // Resets the color
+
+  const levelPrefix = (() => {
+    switch (level) {
+      case "error":
+        return "\x1b[31m"; // Red
+      case "warn":
+        return "\x1b[33m"; // Yellow
+      // case "info":
+      //   return "";
+      default:
+        return "";
+    }
+  })();
+
+  // eslint-disable-next-line no-console -- this is a utility for logging
+  console[level](
+    `${prefixColor}${prefix}${reset}${levelPrefix}${reset} ${messagePrefix}${
+      typeof message === "object"
+        ? `\n${JSON.stringify(message, null, 2)}`
+        : message
+    }${reset}`
+  );
+}
+
+const debug = {
+  log: (message: string, overridePrefix?: string) => {
+    debugLog(message, "log", overridePrefix);
+  },
+  error: (message: string, overridePrefix?: string) => {
+    debugLog(message, "error", overridePrefix);
+  },
+  warn: (message: string, overridePrefix?: string) => {
+    debugLog(message, "warn", overridePrefix);
+  },
+  info: (message: string, overridePrefix?: string) => {
+    debugLog(message, "info", overridePrefix);
+  },
+};
+
+export { debug };


### PR DESCRIPTION
- add settings schema & validation with zod 
- handle errors for parsing settings json
- handle validation errors for settings
- fix bug: we were accidentally adding the ai's message to the payload chat history twice
- add debug logger helper function
- remove cloudflare service and settings (can be replaced easily with custom + headers + payload setting)